### PR TITLE
Fix iOS AOT crash by removing Expression.Compile() from CreateContextFactory

### DIFF
--- a/src/Blazilla/FluentValidator.cs
+++ b/src/Blazilla/FluentValidator.cs
@@ -469,40 +469,21 @@ public class FluentValidator : ComponentBase, IDisposable
 
 
     /// <summary>
-    /// Creates a compiled delegate factory for creating ValidationContext instances of the specified type.
-    /// This avoids the performance overhead of using Activator.CreateInstance with reflection.
+    /// Creates a factory for creating ValidationContext instances of the specified type.
+    /// Uses reflection instead of expression compilation so the component remains safe in iOS AOT-only mode.
     /// </summary>
     /// <param name="modelType">The model type to create a factory for.</param>
-    /// <returns>A compiled delegate that creates ValidationContext instances.</returns>
+    /// <returns>A delegate that creates ValidationContext instances.</returns>
     private static Func<object, PropertyChain?, IValidatorSelector, IValidationContext> CreateContextFactory(Type modelType)
     {
         var contextType = typeof(ValidationContext<>).MakeGenericType(modelType);
 
-        // Get the constructor that takes (T instance, PropertyChain propertyChain, IValidatorSelector validatorSelector)
-        var constructor = contextType.GetConstructor([modelType, typeof(PropertyChain), typeof(IValidatorSelector)])
-            ?? throw new InvalidOperationException($"Could not find appropriate constructor for {contextType}");
+        return (instance, propertyChain, selector) =>
+        {
+            var context = Activator.CreateInstance(contextType, instance, propertyChain, selector);
 
-        // Create expression parameters
-        var instanceParam = Expression.Parameter(typeof(object), "instance");
-        var propertyChainParam = Expression.Parameter(typeof(PropertyChain), "propertyChain");
-        var selectorParam = Expression.Parameter(typeof(IValidatorSelector), "selector");
-
-        // Convert the instance parameter to the correct model type
-        var typedInstance = Expression.Convert(instanceParam, modelType);
-
-        // Create the constructor call expression
-        var constructorCall = Expression.New(constructor, typedInstance, propertyChainParam, selectorParam);
-
-        // Convert the result to IValidationContext
-        var convertedResult = Expression.Convert(constructorCall, typeof(IValidationContext));
-
-        // Compile the expression into a delegate
-        var lambda = Expression.Lambda<Func<object, PropertyChain?, IValidatorSelector, IValidationContext>>(
-            convertedResult,
-            instanceParam,
-            propertyChainParam,
-            selectorParam);
-
-        return lambda.Compile();
+            return context as IValidationContext
+                ?? throw new InvalidOperationException($"Could not create validation context for {modelType}");
+        };
     }
 }


### PR DESCRIPTION
**Summary**
This change fixes an iOS AOT/runtime compatibility issue in FluentValidator.

CreateContextFactory currently builds a delegate with Expression.Compile(). That works on Web and Android, but it can fail on iOS where the app runs in AOT-only mode and runtime code generation is restricted.

This PR replaces the compiled-expression factory with an AOT-safe reflection-based factory using Activator.CreateInstance(...).

**Problem**
When validation is triggered on field change, FluentValidator builds a ValidationContext<T> through a cached factory.

The previous implementation used:
expression tree creation
lambda.Compile()

On iOS, that can crash with an error similar to:
Attempting to JIT compile method ... while running in aot-only mode

**Root Cause**
The issue is not in the validators themselves, but in the internal factory used to create ValidationContext<T> instances.
The old implementation depends on runtime delegate generation, which is not safe in iOS AOT-only environments.

**Fix**
Replace the compiled-expression-based factory with a reflection-based implementation:

- keep the same public behavior
- keep the same caching shape
- remove the dependency on Expression.Compile()
- use Activator.CreateInstance(...) to construct ValidationContext<T>

This avoids runtime code generation and makes the component safe for iOS AOT scenarios.