### PR TITLE
Include the validation state change in the pending validation task

### DIFF
--- a/src/Blazilla/FluentValidator.cs
+++ b/src/Blazilla/FluentValidator.cs
@@ -267,39 +267,42 @@ public class FluentValidator : ComponentBase, IDisposable
         if (context == null)
             return;
 
-        if (AsyncMode)
-        {
-            // wrap the entire validation workflow in a task to prevent race conditions
-            // the pending task must complete both validation AND applying results before
-            // EditContextExtensions.ValidateAsync() can safely check for validation messages
-            var task = _currentValidator
-                .ValidateAsync(context)
-                .ContinueWith(async validationTask =>
-                {
-                    ValidationResult? validationResults = await validationTask.ConfigureAwait(false);
+        // wrap the entire validation workflow in a single task to prevent race conditions
+        // the pending task must complete validation, apply the results AND raise the validation
+        // state change before EditContextExtensions.ValidateAsync() returns, otherwise callers
+        // can observe the messages before the form has re-rendered them
+        var task = ValidateAndNotifyAsync(context);
 
-                    // update messages for all fields
-                    ApplyValidationResults(validationResults);
-                })
-                .Unwrap();
+        // store pending task in EditContext properties so it can be awaited if needed
+        // used in EditContextExtensions.ValidateAsync() to prevent premature form submission
+        _currentContext.Properties[PendingTask] = task;
 
-            // store pending task in EditContext properties so it can be awaited if needed
-            // used in EditContextExtensions.ValidateAsync() to prevent premature form submission
-            _currentContext.Properties[PendingTask] = task;
+        // await the task so message store is updated when task completes
+        await task.ConfigureAwait(false);
+    }
 
-            // await the task so message store is updated when task completes
-            await task.ConfigureAwait(false);
-        }
-        else
-        {
-            ValidationResult? validationResults = _currentValidator.Validate(context);
+    /// <summary>
+    /// Runs full model validation, applies the results to the message store and raises the
+    /// validation state change on the UI thread.
+    /// </summary>
+    /// <param name="context">The validation context describing the model and rules to run.</param>
+    /// <returns>
+    /// A task that completes only after the validation messages have been stored and
+    /// <see cref="EditContext.NotifyValidationStateChanged"/> has been invoked on the renderer
+    /// dispatcher, so awaiting it guarantees the form has been asked to re-render.
+    /// </returns>
+    private async Task ValidateAndNotifyAsync(IValidationContext context)
+    {
+        ValidationResult? validationResults = AsyncMode
+            ? await _currentValidator!.ValidateAsync(context).ConfigureAwait(false)
+            : _currentValidator!.Validate(context);
 
-            // update messages for all fields
-            ApplyValidationResults(validationResults);
-        }
+        // update messages for all fields
+        ApplyValidationResults(validationResults);
 
-        // notify on UI thread
-        _ = InvokeAsync(_currentContext.NotifyValidationStateChanged);
+        // notify on UI thread; awaited so the state change, and the re-render it triggers,
+        // have run before this task completes
+        await InvokeAsync(_currentContext!.NotifyValidationStateChanged).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/test/Blazilla.Tests/ValidationNotificationFormComponent.razor
+++ b/test/Blazilla.Tests/ValidationNotificationFormComponent.razor
@@ -1,0 +1,29 @@
+@typeparam TModel
+
+@*
+    Test form that renders a ValidationSummary so the rendered markup reflects the
+    validation message store only after OnValidationStateChanged has been raised.
+*@
+
+<EditForm EditContext="@EditContext">
+    <FluentValidator Validator="@Validator" AsyncMode="@AsyncMode" />
+    <ValidationSummary />
+</EditForm>
+
+@code {
+    [Parameter]
+    public TModel? Model { get; set; }
+
+    [Parameter]
+    public IValidator? Validator { get; set; }
+
+    [Parameter]
+    public bool AsyncMode { get; set; }
+
+    public EditContext? EditContext { get; private set; }
+
+    protected override void OnInitialized()
+    {
+        EditContext = new EditContext(Model!);
+    }
+}

--- a/test/Blazilla.Tests/ValidationNotificationTests.cs
+++ b/test/Blazilla.Tests/ValidationNotificationTests.cs
@@ -1,0 +1,109 @@
+using BlazorShared.Models;
+using BlazorShared.Validators;
+
+using FluentValidation;
+
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Blazilla.Tests;
+
+/// <summary>
+/// Regression tests for the race between populating the validation message store and raising the
+/// validation state change that renders those messages.
+/// <see cref="EditContextExtensions.ValidateAsync(EditContext)"/> must not return until
+/// <see cref="EditContext.NotifyValidationStateChanged"/> has run, otherwise a caller that inspects
+/// the rendered output right after awaiting validation races the re-render.
+/// </summary>
+public class ValidationNotificationTests : BunitContext
+{
+    // repeat the timing sensitive assertions to catch the ordering race,
+    // which previously surfaced only intermittently
+    private const int RaceIterations = 25;
+
+    private readonly AddressValidator _addressValidator = new();
+
+    public ValidationNotificationTests()
+    {
+        Services.AddSingleton<IValidator<Address>>(_addressValidator);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ValidateAsync_RaisesValidationStateChanged_BeforeReturning(bool asyncMode)
+    {
+        for (var iteration = 0; iteration < RaceIterations; iteration++)
+        {
+            // Arrange - an address that fails validation
+            var component = RenderForm(new Address(), asyncMode);
+            var editContext = component.Instance.EditContext!;
+
+            var notifications = 0;
+            editContext.OnValidationStateChanged += (_, _) => notifications++;
+
+            // Act
+            var result = await editContext.ValidateAsync();
+
+            // Assert - the state change must already have been raised, without waiting for it
+            result.Should().BeFalse();
+            notifications.Should().BeGreaterThan(0, "ValidateAsync must not return before the validation state change is raised");
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ValidateAsync_RendersValidationMessages_BeforeReturning(bool asyncMode)
+    {
+        for (var iteration = 0; iteration < RaceIterations; iteration++)
+        {
+            // Arrange - an address that fails validation
+            var component = RenderForm(new Address(), asyncMode);
+            var editContext = component.Instance.EditContext!;
+
+            // Act
+            var result = await editContext.ValidateAsync();
+
+            // Assert - no WaitForAssertion polling: the messages must already be rendered
+            result.Should().BeFalse();
+            component.Markup.Should().Contain(AddressValidator.Line1Required);
+            component.Markup.Should().Contain(AddressValidator.CityRequired);
+            component.Markup.Should().Contain(AddressValidator.StateProvinceRequired);
+            component.Markup.Should().Contain(AddressValidator.PostalCodeRequired);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ValidateAsync_ClearsRenderedMessages_BeforeReturning(bool asyncMode)
+    {
+        // Arrange - start invalid so messages are rendered, then make the model valid
+        var address = new Address();
+        var component = RenderForm(address, asyncMode);
+        var editContext = component.Instance.EditContext!;
+
+        await editContext.ValidateAsync();
+        component.Markup.Should().Contain(AddressValidator.CityRequired);
+
+        address.AddressLine1 = "123 Main St";
+        address.City = "Test City";
+        address.StateProvince = "TS";
+        address.PostalCode = "12345";
+
+        // Act
+        var result = await editContext.ValidateAsync();
+
+        // Assert - the cleared store must already be reflected in the markup
+        result.Should().BeTrue();
+        component.Markup.Should().NotContain(AddressValidator.CityRequired);
+    }
+
+    private IRenderedComponent<ValidationNotificationFormComponent<Address>> RenderForm(Address address, bool asyncMode)
+    {
+        return Render<ValidationNotificationFormComponent<Address>>(parameters => parameters
+            .Add(p => p.Model, address)
+            .Add(p => p.Validator, _addressValidator)
+            .Add(p => p.AsyncMode, asyncMode));
+    }
+}


### PR DESCRIPTION
## Problem

`FluentValidator.OnValidationRequested` stored the validate-and-apply task in `EditContext.Properties[PendingTask]`, then raised `NotifyValidationStateChanged` from a separate un-awaited `InvokeAsync` in a *sibling* continuation on that same task:

```csharp
var task = _currentValidator.ValidateAsync(context)
    .ContinueWith(async t => { ApplyValidationResults(await t); })
    .Unwrap();

_currentContext.Properties[PendingTask] = task;
await task.ConfigureAwait(false);
...
_ = InvokeAsync(_currentContext.NotifyValidationStateChanged);   // fire-and-forget
```

`EditContextExtensions.ValidateAsync` awaits that same stored task, so its continuation and the component's own `await task` are two independent continuations on one `Task` with no ordering guarantee between them. When a caller resumes from `await editContext.ValidateAsync()`, the message store is guaranteed populated — but the `NotifyValidationStateChanged` that makes `<ValidationSummary />` / `<ValidationMessage />` re-render may not have run yet, since it is posted from the sibling continuation and never awaited.

Any consumer that awaits validation and then immediately looks at rendered output races the render — a bUnit test reading `component.Markup`, or UI logic keyed off the DOM right after `ValidateAsync` returns. It usually wins, and occasionally doesn't. This repo's own `AddressFormTests` / `PersonFormTests` already work around it with `WaitForAssertion` polling.

## Fix

The whole workflow becomes one linear async method, so the stored task completes only after the results are applied **and** the validation state change has run on the renderer dispatcher:

```csharp
var task = ValidateAndNotifyAsync(context);
_currentContext.Properties[PendingTask] = task;
await task.ConfigureAwait(false);
```

```csharp
private async Task ValidateAndNotifyAsync(IValidationContext context)
{
    ValidationResult? validationResults = AsyncMode
        ? await _currentValidator!.ValidateAsync(context).ConfigureAwait(false)
        : _currentValidator!.Validate(context);

    ApplyValidationResults(validationResults);

    await InvokeAsync(_currentContext!.NotifyValidationStateChanged).ConfigureAwait(false);
}
```

Notes on the details:

- `ContinueWith(...).Unwrap()` is gone. `ValidateAsync`'s await is now the only continuation on the stored task, so there is nothing left to order against.
- The pending task is now stored in **both** modes. Synchronous mode previously stored nothing, so `ValidateAsync` awaited nothing and the notification was still an un-awaited post whenever validation was raised off the renderer dispatcher.
- `ApplyValidationResults` deliberately stays **outside** `InvokeAsync`. Moving it inside would break the synchronous `EditContextExtensions.Validate` extension, which reads `GetValidationMessages()` immediately and is routinely called from a non-dispatcher thread.

`EditContextExtensions` is unchanged — awaiting the stored task now implies the render call has happened, so no second notification is needed there.

`OnFieldChanged`'s fire-and-forget notification is left alone: it is `async void` with no awaitable channel out, so no caller contract is broken there. Fixing it needs a different design and belongs in its own change.

## Tests

New `ValidationNotificationTests` + `ValidationNotificationFormComponent.razor`: a form with `FluentValidator` and `ValidationSummary`, awaiting `editContext.ValidateAsync()` from the test thread (not the dispatcher) and asserting directly on `component.Markup` with **no `WaitForAssertion` polling**. Three theories over `AsyncMode` true/false — state change raised, messages rendered, messages cleared on revalidate — each looping 25x to shake out the ordering race.

Verified in both directions:

- Against unmodified `main`, all three `asyncMode: true` cases fail — `notifications: 0`, and the markup is literally `<form></form>` because the render had not happened yet.
- With the fix, 236/236 tests pass, stable across 5 consecutive full-suite runs. Release build is clean with 0 warnings, Meziantou analyzers included.

The existing `WaitForAssertion` workarounds in `AddressFormTests` / `PersonFormTests` could be tightened now that the guarantee holds, but I left them alone to keep this diff reviewable.

Follow-up to "Fix async validation by wrapping the entire validation workflow in a task (both validation AND applying results)", which closed the validation-vs-message-store half of this race but left the message-store-vs-render half open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)