### PR TITLE
Avoid wasted effort on highly connected object graphs

### DIFF
--- a/src/Blazilla/PathResolver.cs
+++ b/src/Blazilla/PathResolver.cs
@@ -105,8 +105,15 @@ public class PathResolver
         _pathStack.Clear();
         _currentDepth = 0;
 
-        if (TryFindInCurrent(rootObject, targetInstance, targetProperty))
-            return _pathStack.ToString();
+        try
+        {
+            if (TryFindInCurrent(rootObject, targetInstance, targetProperty))
+                return _pathStack.ToString();
+        }
+        finally
+        {
+            _visitedObjects.Clear();
+        }
 
         return null;
     }
@@ -215,7 +222,6 @@ public class PathResolver
         }
         finally
         {
-            _visitedObjects.Remove(current);
             _currentDepth--;
         }
     }


### PR DESCRIPTION
This patch retains objects in `_visitedObjects` until the root call to `TryFindInCurrent` returns, preventing unnecessary wasted effort when working on highly connected object graphs.

Resolves #197